### PR TITLE
Install packages in preseed

### DIFF
--- a/ubuntu16.04.2/templates/compute_postscript.j2
+++ b/ubuntu16.04.2/templates/compute_postscript.j2
@@ -39,5 +39,5 @@ wget -O /root/firstboot.sh http://10.0.0.254/firstboot.sh
 wget -O /etc/rc.local http://10.0.0.254/rc.local
 chmod +x /etc/rc.local /root/firstboot.sh
 
-#apt update
-#apt install ntp ssh wget nfs-common infiniband-diags openmpi-bin libopenmpi-dev python-mpi4py libmthca-dev librdmacm-dev libibumad-dev libibverbs-dev libibmad-dev libibcm-dev libmlx4-dev make g++ libtool perftest autoconf automake
+apt-get update
+apt-get -y install autoconf automake dkms g++ htop ibacm ibutils ibverbs-utils infiniband-diags libibcm-dev libibcm.* libibmad-dev libibmad.* libibumad-dev libibumad* libibverbs-dev libibverbs* libmlx4-dev libmlx4* libmlx5* libmthca-dev libopenmpi-dev librdmacm-dev librdmacm* libtool make mstflint nfs-common ntp openmpi-bin opensm perftest python-mpi4py rdmacm-utils srptools ssh tree vlan wget


### PR DESCRIPTION
Provides for installation of Infiniband tools (and others) so computes can run basic Infiniband diagnostics and bandwidth tests out of the box.

### ibstat

```
comet@vm-vct02-00:~$ ibstat
CA 'mlx4_0'
	CA type: MT4100
	Number of ports: 1
	Firmware version: 2.31.5050
	Hardware version: 1
	Node GUID: 0x001405009b1cfc49
	System image GUID: 0xf4521403004eb783
	Port 1:
		State: Active
		Physical state: LinkUp
		Rate: 56
		Base lid: 17
		LMC: 0
		SM lid: 1
		Capability mask: 0x02514868
		Port GUID: 0x9152ca5fa800011f
		Link layer: InfiniBand
```

### ib_read_bw

```
comet@vm-vct02-00:~$ sudo ib_read_bw -a 10.1.0.2
---------------------------------------------------------------------------------------
                    RDMA_Read BW Test
 Dual-port       : OFF		Device         : mlx4_0
 Number of qps   : 1		Transport type : IB
 Connection type : RC		Using SRQ      : OFF
 TX depth        : 128
 CQ Moderation   : 100
 Mtu             : 2048[B]
 Link type       : IB
 Outstand reads  : 16
 rdma_cm QPs	 : OFF
 Data ex. method : Ethernet
---------------------------------------------------------------------------------------
 local address: LID 0x11 QPN 0x0a67 PSN 0xd8f21a OUT 0x10 RKey 0xd8010f00 VAddr 0x002ad0b99c0000
 remote address: LID 0x3c QPN 0x0a69 PSN 0x6c03b2 OUT 0x10 RKey 0x98010f00 VAddr 0x002b48c2660000
---------------------------------------------------------------------------------------
 #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]
 2          1000             14.59              14.35  		   7.523986
 4          1000             29.01              28.33  		   7.425562
 8          1000             58.02              56.93  		   7.461571
 16         1000             118.20             118.02 		   7.734244
 32         1000             224.54             223.15 		   7.312103
 64         1000             462.72             454.86 		   7.452386
 128        1000             939.72             936.95 		   7.675527
 256        1000             1659.24            1654.71		   6.777672
 512        1000             3091.07            3071.56		   6.290555
 1024       1000             4552.83            4550.49		   4.659697
 2048       1000             5424.87            5420.97		   2.775539
 4096       1000             5816.75            5816.47		   1.489017
 8192       1000             6045.96            6045.03		   0.773763
 16384      1000             6076.12            6075.38		   0.388824
 32768      1000             6078.02            6077.59		   0.194483
 65536      1000             6082.05            6081.10		   0.097298
 131072     1000             6080.98            6080.69		   0.048645
 262144     1000             6082.52            6081.18		   0.024325
 524288     1000             6077.66            6077.64		   0.012155
 1048576    1000             6078.58            6077.93		   0.006078
 2097152    1000             6066.24            6065.21		   0.003033
 4194304    1000             6063.24            6063.04		   0.001516
 8388608    1000             6074.22            6073.29		   0.000759
---------------------------------------------------------------------------------------
```