### PR TITLE
Add support for NFS home directory on compute nodes

### DIFF
--- a/ubuntu16.04.2/fe_deploy.yml
+++ b/ubuntu16.04.2/fe_deploy.yml
@@ -311,8 +311,16 @@
     args:
       creates: "{{ ansible_user_dir }}/.ssh/id_rsa"
 
+  - name: Set trust on SSH key on frontend
+    shell: /bin/cat "{{ ansible_user_dir }}"/.ssh/id_rsa.pub >> "{{ ansible_user_dir }}/.ssh/authorized_keys"
+
+  - name: Set perms on authorized_keys
+    file:
+      dest: "{{ ansible_user_dir }}/.ssh/authorized_keys"
+      mode: "a+x"
+
   - name: Read id_rsa.pub key content
-    shell: /bin/cat "{{ ansible_user_dir}}"/.ssh/id_rsa.pub
+    shell: /bin/cat "{{ ansible_user_dir }}"/.ssh/id_rsa.pub
     register: PUBLIC_KEY
 
   - name: postscript installation

--- a/ubuntu16.04.2/fe_deploy.yml
+++ b/ubuntu16.04.2/fe_deploy.yml
@@ -148,6 +148,20 @@
       line: '/home 10.0.0.0/24(rw,sync)'
     become: true
 
+  - name: auto.master for computes
+    template:
+      src: fe_etc_auto_master.j2
+      dest: /var/www/html/auto.master
+    ignore_errors: yes
+    become: true
+
+  - name: auto.home for computes
+    template:
+      src: fe_etc_auto_home.j2
+      dest: /var/www/html/auto.home
+    ignore_errors: yes
+    become: true
+
   - name: config inetd.conf
     lineinfile:
       dest: /etc/inetd.conf

--- a/ubuntu16.04.2/fe_deploy.yml
+++ b/ubuntu16.04.2/fe_deploy.yml
@@ -31,7 +31,7 @@
     file:
       dest: "{{ansible_user_dir}}/cmutil.py"
       mode: "a+x"
-  
+
   - name: Update repository cache if necessary
     apt:
       update_cache: yes
@@ -130,7 +130,7 @@
   - name: config dhcp
     lineinfile:
       dest: /etc/default/isc-dhcp-server
-      line: 'INTERFACES="ens3"'  
+      line: 'INTERFACES="ens3"'
     become: true
 
   - name: config tftp - set as daemon

--- a/ubuntu16.04.2/fe_deploy.yml
+++ b/ubuntu16.04.2/fe_deploy.yml
@@ -45,6 +45,9 @@
     with_items:
       - curl
       - git
+      - htop
+      - vim
+      - bc
       - apache2
       - tftpd-hpa
       - isc-dhcp-server

--- a/ubuntu16.04.2/templates/compute_postscript.j2
+++ b/ubuntu16.04.2/templates/compute_postscript.j2
@@ -37,7 +37,9 @@ echo  '
 wget -O /etc/hosts http://10.0.0.254/hosts
 wget -O /root/firstboot.sh http://10.0.0.254/firstboot.sh
 wget -O /etc/rc.local http://10.0.0.254/rc.local
+wget -O /etc/auto.master http://10.0.0.254/auto.master
+wget -O /etc/auto.home http://10.0.0.254/auto.home
 chmod +x /etc/rc.local /root/firstboot.sh
 
 apt-get update
-apt-get -y install autoconf automake dkms g++ htop ibacm ibutils ibverbs-utils infiniband-diags libibcm-dev libibcm.* libibmad-dev libibmad.* libibumad-dev libibumad* libibverbs-dev libibverbs* libmlx4-dev libmlx4* libmlx5* libmthca-dev libopenmpi-dev librdmacm-dev librdmacm* libtool make mstflint nfs-common ntp openmpi-bin opensm perftest python-mpi4py rdmacm-utils srptools ssh tree vlan wget
+apt-get -y install autoconf autofs automake dkms g++ htop ibacm ibutils ibverbs-utils infiniband-diags libibcm-dev libibcm.* libibmad-dev libibmad.* libibumad-dev libibumad* libibverbs-dev libibverbs* libmlx4-dev libmlx4* libmlx5* libmthca-dev libopenmpi-dev librdmacm-dev librdmacm* libtool make mstflint nfs-common ntp openmpi-bin opensm perftest python-mpi4py rdmacm-utils srptools ssh tree vim vlan wget

--- a/ubuntu16.04.2/templates/fe_etc_auto_home.j2
+++ b/ubuntu16.04.2/templates/fe_etc_auto_home.j2
@@ -1,0 +1,1 @@
+{{ ansible_user_id  }}      -nodev,nosuid,hard,tcp,nfsvers=3,intr,rsize=32768,wsize=32768        10.0.0.254:/home/{{ ansible_user_id  }}

--- a/ubuntu16.04.2/templates/fe_etc_auto_master.j2
+++ b/ubuntu16.04.2/templates/fe_etc_auto_master.j2
@@ -1,0 +1,3 @@
++dir:/etc/auto.master.d
++auto.master
+/home     /etc/auto.home


### PR DESCRIPTION
### Deployed and tested on vct02...

```
comet@vct02:~$ pdsh -R ssh -w vm-vct02-[00,01] mount -t nfs
vm-vct02-01: 10.0.0.254:/home/comet on /home/comet type nfs (rw,nosuid,nodev,relatime,vers=3,rsize=32768,wsize=32768,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=10.0.0.254,mountvers=3,mountport=47997,mountproto=tcp,local_lock=none,addr=10.0.0.254)
vm-vct02-00: 10.0.0.254:/home/comet on /home/comet type nfs (rw,nosuid,nodev,relatime,vers=3,rsize=32768,wsize=32768,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=10.0.0.254,mountvers=3,mountport=47997,mountproto=tcp,local_lock=none,addr=10.0.0.254)
```